### PR TITLE
Fix nil pointer exception in pvc

### DIFF
--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "ozwdaemon.fullname" . }}
-  {{- if .Values.persistence.config.skipuninstall }}
+  {{- if .Values.persistence.skipuninstall }}
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}


### PR DESCRIPTION
This PR fixes a nil pointer exception with an extra key in the pvc template.

```
Error: template: ozwdaemon/templates/pvc.yaml:6:16: executing "ozwdaemon/templates/pvc.yaml" at <.Values.persistence.config.skipuninstall>: nil pointer evaluating interface {}.skipuninstall
```